### PR TITLE
Add snooze button to signal instance message in Slack plugin and add Case/Signal subject enum (#3073)

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/case/enums.py
@@ -2,7 +2,6 @@ from dispatch.enums import DispatchEnum
 
 
 class CaseNotificationActions(DispatchEnum):
-    snooze = "case-notification-snooze"
     escalate = "case-notification-escalate"
     resolve = "case-notification-resolve"
     reopen = "case-notification-reopen"
@@ -24,11 +23,6 @@ class CaseResolveActions(DispatchEnum):
     submit = "case-notification-resolve-submit"
 
 
-class CaseSnoozeActions(DispatchEnum):
-    preview = "case-notification-snooze-preview"
-    submit = "case-notification-snooze-submit"
-
-
 class CaseEscalateActions(DispatchEnum):
     submit = "case-notification-escalate-submit"
     project_select = "case-notification-escalate-project-select"
@@ -44,4 +38,10 @@ class CaseShortcutCallbacks(DispatchEnum):
 
 
 class SignalNotificationActions(DispatchEnum):
+    snooze = "signal-notification-snooze"
     view = "signal-notification-view"
+
+
+class SignalSnoozeActions(DispatchEnum):
+    preview = "case-notification-snooze-preview"
+    submit = "case-notification-snooze-submit"

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -4,7 +4,7 @@ from blockkit import Actions, Button, Context, Message, Section, Divider, Overfl
 from dispatch.config import DISPATCH_UI_URL
 from dispatch.case.enums import CaseStatus
 from dispatch.case.models import Case
-from dispatch.plugins.dispatch_slack.models import SubjectMetadata
+from dispatch.plugins.dispatch_slack.models import SubjectMetadata, CaseSubjects, SignalSubjects
 from dispatch.plugins.dispatch_slack.case.enums import (
     CaseNotificationActions,
     SignalNotificationActions,
@@ -38,7 +38,7 @@ def create_case_message(case: Case, channel_id: str):
     ]
 
     button_metadata = SubjectMetadata(
-        type="case",
+        type=CaseSubjects.case,
         organization_slug=case.project.organization.slug,
         id=case.id,
         project_id=case.project.id,
@@ -128,7 +128,7 @@ def create_signal_messages(case: Case, channel_id: str) -> List[Message]:
 
     for instance in case.signal_instances:
         button_metadata = SubjectMetadata(
-            type="signalInstance",
+            type=SignalSubjects.signal_instance,
             organization_slug=case.project.organization.slug,
             id=str(instance.id),
             project_id=case.project.id,
@@ -143,7 +143,17 @@ def create_signal_messages(case: Case, channel_id: str) -> List[Message]:
                     action_id=SignalNotificationActions.view,
                     value=button_metadata,
                 ),
-            )
+            ),
+            Actions(
+                elements=[
+                    Button(
+                        text="Snooze",
+                        action_id=SignalNotificationActions.snooze,
+                        style="primary",
+                        value=button_metadata,
+                    )
+                ]
+            ),
         ]
 
         # group entities by entity type

--- a/src/dispatch/plugins/dispatch_slack/models.py
+++ b/src/dispatch/plugins/dispatch_slack/models.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from pydantic import BaseModel
 
+from dispatch.enums import DispatchEnum
+
 
 class SubjectMetadata(BaseModel):
     id: Optional[str]
@@ -29,3 +31,12 @@ class SubjectMetadata(BaseModel):
 
     project_id: Optional[str]
     channel_id: Optional[str]
+
+
+class CaseSubjects(DispatchEnum):
+    case = "case"
+
+
+class SignalSubjects(DispatchEnum):
+    signal = "signal"
+    signal_instance = "signal_instance"

--- a/src/dispatch/signal/models.py
+++ b/src/dispatch/signal/models.py
@@ -28,7 +28,7 @@ from dispatch.project.models import ProjectRead
 
 from dispatch.database.core import Base
 from dispatch.entity.models import EntityRead
-from dispatch.entity_type.models import EntityTypeCreate, EntityTypeRead
+from dispatch.entity_type.models import EntityTypeRead
 from dispatch.tag.models import TagRead
 from dispatch.enums import DispatchEnum
 from dispatch.models import (
@@ -229,7 +229,9 @@ class SignalCreate(SignalBase):
 
 class SignalUpdate(SignalBase):
     id: PrimaryKey
+    filters: Optional[List[SignalFilterRead]] = []
     entity_types: Optional[List[EntityTypeRead]] = []
+    tags: Optional[List[TagRead]] = []
 
 
 class SignalRead(SignalBase):


### PR DESCRIPTION
* Add buttom template and add subject enum

* Adds signal retrieval for instance case

* use subject var

* Switch snooze to signal notification enum

* Account for not being inside a modal

* unused import

* rename case snooze enum symbol to signal snooze

* fix pytest for signalUpdate